### PR TITLE
Feat/mc 26.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,10 +54,10 @@ compileJava {options.encoding = "UTF-8"}
 def targetJavaVersion = 21
 
 shadowJar {
-    relocate 'org.bstats', 'pl.norbit.treecuter.bstats'
-    relocate 'fr.skytasul.glowingentities', 'pl.norbit.treecuter.skytasul.glowingentities'
+    relocate 'org.bstats', 'pl.norbit.treecuter.libs.bstats'
+    relocate 'fr.skytasul.glowingentities', 'pl.norbit.treecuter.libs.skytasul.glowingentities'
     exclude "fr/skytasul/reflection/Version*.class"
-    relocate 'fr.skytasul.reflection', 'pl.norbit.treecuter.skytasul.reflection'
+    relocate 'fr.skytasul.reflection', 'pl.norbit.treecuter.libs.skytasul.reflection'
     archiveClassifier.set("")
     mergeServiceFiles()
 }

--- a/src/main/java/pl/norbit/treecuter/libs/skytasul/reflection/Version.java
+++ b/src/main/java/pl/norbit/treecuter/libs/skytasul/reflection/Version.java
@@ -72,7 +72,7 @@ public record Version(int major, int minor, int patch) implements Comparable<Ver
 
         // String[] parts = string.split("\\.");
         // Narrow parts down to the last numeric part before the first non-numerical part, supporting versions like "26.1.1.build.1234"
-        String[] parts = Stream.of(string.split("\\.")).filter(s -> s.matches("\\d+")).toArray(String[]::new);
+        String[] parts = Stream.of(str.split("\\.")).filter(s -> s.matches("\\d+")).toArray(String[]::new);
         if (parts.length < 2 || parts.length > 3) {
             throw new IllegalArgumentException("Malformed version: " + string);
         }

--- a/src/main/java/pl/norbit/treecuter/libs/skytasul/reflection/Version.java
+++ b/src/main/java/pl/norbit/treecuter/libs/skytasul/reflection/Version.java
@@ -1,7 +1,9 @@
-package pl.norbit.treecuter.skytasul.reflection;
+package pl.norbit.treecuter.libs.skytasul.reflection;
 
 import java.util.stream.Stream;
+
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Patched version of {@link fr.skytasul.reflection.Version}
@@ -59,20 +61,37 @@ public record Version(int major, int minor, int patch) implements Comparable<Ver
         return omitPatch && this.patch == 0 ? "%d.%d".formatted(this.major, this.minor) : "%d.%d.%d".formatted(this.major, this.minor, this.patch);
     }
 
-    public static @NotNull Version parse(@NotNull String string) throws IllegalArgumentException {
+    public static @NotNull Version parse(@NotNull String string) {
         if (string.isBlank()) {
             throw new IllegalArgumentException("Version string cannot be blank");
         }
+
+        // '-' never appears but after patch or minor version
+        int dash = string.indexOf('-');
+        String str = (dash == -1) ? string : string.substring(0, dash);
+
         // String[] parts = string.split("\\.");
         // Narrow parts down to the last numeric part before the first non-numerical part, supporting versions like "26.1.1.build.1234"
         String[] parts = Stream.of(string.split("\\.")).filter(s -> s.matches("\\d+")).toArray(String[]::new);
-        if (parts.length >= 2 && parts.length <= 3) {
+        if (parts.length < 2 || parts.length > 3) {
+            throw new IllegalArgumentException("Malformed version: " + string);
+        }
+
+        try {
             int major = Integer.parseInt(parts[0]);
             int minor = Integer.parseInt(parts[1]);
             int patch = parts.length == 3 ? Integer.parseInt(parts[2]) : 0;
             return new Version(major, minor, patch);
-        } else {
-            throw new IllegalArgumentException("Malformed version: " + string);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Malformed version: " + string, e);
+        }
+    }
+
+    public static @Nullable Version parseOrNull(@NotNull String string) {
+        try {
+            return parse(string);
+        } catch (RuntimeException e) {
+            return null;
         }
     }
 

--- a/src/main/java/pl/norbit/treecuter/utils/GlowUtils.java
+++ b/src/main/java/pl/norbit/treecuter/utils/GlowUtils.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import pl.norbit.treecuter.config.Settings;
 import pl.norbit.treecuter.exception.GlowException;
+import pl.norbit.treecuter.libs.skytasul.reflection.Version;
 import pl.norbit.treecuter.model.GlowBlock;
 
 import java.util.List;
@@ -18,10 +19,10 @@ import java.util.logging.Logger;
 
 public class GlowUtils {
     private static final Map<Player, GlowBlock> blocks = new ConcurrentHashMap<>();
-    private static final List<String> supportedGlowingVersions =
-            List.of("1.17.1", "1.18.2", "1.19.4", "1.20.2", "1.20.4", "1.20.5", "1.20.6", "1.21.1"," 1.21.2",
+    private static final List<Version> supportedGlowingVersions =
+            List.of(Version.parseArray("1.17.1", "1.18.2", "1.19.4", "1.20.2", "1.20.4", "1.20.5", "1.20.6", "1.21.1", " 1.21.2",
                     "1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10", "1.21.11",
-                    "26.1.1");
+                    "26.1", "26.1.1", "26.1.2"));
     private static GlowingBlocks glowingBlocks;
     private static boolean enable;
 
@@ -30,10 +31,11 @@ public class GlowUtils {
     }
 
     public static boolean isSupportedVersion(String version){
-        return supportedGlowingVersions.stream()
-                .filter(version::contains)
-                .findFirst()
-                .orElse(null) != null;
+        Version parsedVersion = Version.parseOrNull(version);
+        if (parsedVersion == null) {
+            return false;
+        }
+        return supportedGlowingVersions.contains(parsedVersion);
     }
 
     public static void init(JavaPlugin instance){


### PR DESCRIPTION
Refactor library relocation and version handling

- Move shaded libraries under a unified `libs` namespace
- Improve Version parsing ('-' has never appeared but after patch or minor number in the bukkit version string)
- Add Version#parseOrNull utility method
- Refactor GlowUtils to use Version instead of string matching
- Added '26.1', '26.1.1' and '26.1.2' as supported glowing versions