### PR TITLE
Version fixes

### DIFF
--- a/src/main/java/pl/norbit/treecuter/libs/skytasul/reflection/Version.java
+++ b/src/main/java/pl/norbit/treecuter/libs/skytasul/reflection/Version.java
@@ -72,9 +72,9 @@ public record Version(int major, int minor, int patch) implements Comparable<Ver
 
         // String[] parts = string.split("\\.");
         // Narrow parts down to the last numeric part before the first non-numerical part, supporting versions like "26.1.1.build.1234"
-        String[] parts = Stream.of(str.split("\\.")).filter(s -> s.matches("\\d+")).toArray(String[]::new);
+        String[] parts = Stream.of(str.split("\\.")).takeWhile(s -> s.matches("\\d+")).toArray(String[]::new);
         if (parts.length < 2 || parts.length > 3) {
-            throw new IllegalArgumentException("Malformed version: " + string);
+            throw new IllegalArgumentException("Malformed version (Not 2 or 3 parts): " + string);
         }
 
         try {
@@ -96,7 +96,7 @@ public record Version(int major, int minor, int patch) implements Comparable<Ver
     }
 
     public static @NotNull Version @NotNull [] parseArray(String... versions) {
-        return (Version[])Stream.of(versions).map(Version::parse).toArray((x$0) -> new Version[x$0]);
+        return Stream.of(versions).map(Version::parse).toArray(Version[]::new);
     }
 }
 

--- a/src/main/java/pl/norbit/treecuter/utils/GlowUtils.java
+++ b/src/main/java/pl/norbit/treecuter/utils/GlowUtils.java
@@ -20,7 +20,7 @@ import java.util.logging.Logger;
 public class GlowUtils {
     private static final Map<Player, GlowBlock> blocks = new ConcurrentHashMap<>();
     private static final List<Version> supportedGlowingVersions =
-            List.of(Version.parseArray("1.17.1", "1.18.2", "1.19.4", "1.20.2", "1.20.4", "1.20.5", "1.20.6", "1.21.1", " 1.21.2",
+            List.of(Version.parseArray("1.17.1", "1.18.2", "1.19.4", "1.20.2", "1.20.4", "1.20.5", "1.20.6", "1.21.1", "1.21.2",
                     "1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10", "1.21.11",
                     "26.1", "26.1.1", "26.1.2"));
     private static GlowingBlocks glowingBlocks;


### PR DESCRIPTION
Changes:
- `takeWhile` is used instead of `filter` to actually stop collecting numbers after reading "build".
- `Version#parseArray` has been simplified.
- The version string "1.21.2" contained a space, causing `Version#parseArray` to fail and crash the plugin when initializing `GlowUtils`.

Notes:
- Using `Version` in `GlowUtils` instead of `String` to list supported Glowing versions is intended to prevent version strings like "26.1" or "1.21" from matching any server version that begins with those strings if they are not specifically listed.

Sorry for letting this slide and not testing fully in my last PR.